### PR TITLE
test: add synthetic data generator

### DIFF
--- a/src/synthetic_data_generator/Makefile
+++ b/src/synthetic_data_generator/Makefile
@@ -1,0 +1,18 @@
+all: gen.cpp sample_t.hpp params.hpp sample_file.hpp sample_file.o params.o file_utils.o
+	${CXX} -std=c++11 -Wall -o gen gen.cpp sample_file.o params.o file_utils.o
+
+params.o: sample_t.hpp params.hpp params.cpp
+	${CXX} -std=c++11 -Wall -c params.cpp
+
+sample_files.o: sample_t.hpp params.o file_utils.o sample_files.hpp sample_files.cpp
+	${CXX} -std=c++11 -Wall -c sample_files.cpp params.o
+
+file_utils.o: file_utils.hpp file_utils.cpp
+	${CXX} -std=c++11 -Wall -c file_utils.cpp
+
+
+clean:
+	@rm -f gen *.o
+
+cleandata:
+	@rm -f sample_file.*.txt sample_file.*.bin

--- a/src/synthetic_data_generator/file_utils.cpp
+++ b/src/synthetic_data_generator/file_utils.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include "file_utils.hpp"
+
+bool check_if_file_exists(const std::string& filename) {
+  std::ifstream ifile(filename);
+  return static_cast<bool>(ifile);
+}
+
+bool create_dir(std::string dirname) {
+  if (!dirname.empty() && (dirname.back() == '/')) {
+    dirname.pop_back();
+  }
+
+  if (dirname.empty()) {
+    return true;
+  }
+
+  const bool file_exists = check_if_file_exists(dirname);
+
+  if (file_exists) {
+    if (!check_if_file_exists(dirname)) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  std::string cmd = std::string("mkdir -p ") + dirname;
+  char command_string[cmd.size()+1];
+  std::copy(cmd.begin(), cmd.end(), &command_string[0]);
+  command_string[cmd.size()] = '\0';
+  const int r = ::system(&command_string[0]);
+
+  if (WEXITSTATUS(r) == 0x10) {
+    return true;
+  } else if (!check_if_file_exists(dirname)) {
+    return false;
+  }
+  return true;
+}

--- a/src/synthetic_data_generator/file_utils.hpp
+++ b/src/synthetic_data_generator/file_utils.hpp
@@ -1,0 +1,9 @@
+#ifndef __SGG_FILE_UTILS__
+#define __SGG_FILE_UTILS__
+
+#include <string>
+
+bool check_if_file_exists(const std::string& filename);
+bool create_dir(const std::string dirname);
+
+#endif // __SGG_FILE_UTILS__

--- a/src/synthetic_data_generator/gen.cpp
+++ b/src/synthetic_data_generator/gen.cpp
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "sample_t.hpp"
+#include "params.hpp"
+#include "sample_file.hpp"
+
+using namespace synthetic_sample_generator;
+
+
+void show_help(const std::string executable_name)
+{
+  std::cout << "Usage1: " << executable_name << "out_dir num_samples num_samples_per_file scale_mean scale_variance bias_mean bias_variance mode" << std::endl;
+  std::cout << "        Generate regression samples [X, Y] as many as 'num_samples'," << std::endl;
+  std::cout << "        where X is random, and Y is roughly \"scale_mean * X + bias_mean\"." << std::endl;
+  std::cout << "        Pack samples into files, each of which contains 'num_samples_per_file' samples, written into 'out_dir'." << std::endl;
+  std::cout << "        mode 0: text, mode 1: binary" << std::endl;
+  std::cout << "Usage2: " << executable_name << " file1 file2 scale_mean scale_variance bias_mean bias_variance" << std::endl;
+  std::cout << "        Compare file1 and file2. Only supports files generated using static seeds" << std::endl;
+  std::cout << "Usage3: " << executable_name << " file" << std::endl;
+  std::cout << "        Read a file and print it out" << std::endl;
+}
+
+int main(int argc, char** argv)
+{
+  params p;
+  p.set_seeds(311, 511, 911);
+
+  if (argc == 2) {
+    std::vector<sample_t> samples;
+    load_a_file(argv[1], samples);
+    return 0;
+  } else if (argc == 7) {
+    const std::string file1 = argv[1];
+    const std::string file2 = argv[2];
+
+    if (!p.init_compare(argc, argv)) {
+      return 0;
+    }
+
+    bool is_same = compare(file1, file2, p);
+
+    std::cout << file1 << " and " << file2 << " are " << (is_same? "same" : "different") << std::endl;
+    return 0;
+  } else if (argc != 9) {
+    show_help(argv[0]);
+    return 0;
+  }
+
+  if (!p.init_generate(argc, argv)) {
+    return 0;
+  }
+
+  std::vector<sample_t> samples;
+  samples.reserve(p.n_per_file);
+
+  for (unsigned nf = 0u; nf < p.n_full_files; ++nf) {
+    const std::string ofile_name = p.out_dir + "sample_file." + std::to_string(nf) + (p.is_binary ? ".bin" : ".txt");
+    generate_a_file(ofile_name, p.n_per_file, p, samples);
+  }
+
+  if (p.n_remainder > 0u) {
+    const std::string ofile_name = p.out_dir + "sample_file." + std::to_string(p.n_full_files) + (p.is_binary ? ".bin" : ".txt");
+    generate_a_file(ofile_name, p.n_remainder, p, samples);
+  }
+
+  return 0;
+}

--- a/src/synthetic_data_generator/params.cpp
+++ b/src/synthetic_data_generator/params.cpp
@@ -1,0 +1,95 @@
+#include "sample_t.hpp"
+#include <string>
+#include <random>
+#include <chrono>
+#include "params.hpp"
+#include "file_utils.hpp"
+
+namespace synthetic_sample_generator {
+
+void params::set_seeds(unsigned seed1, unsigned seed2, unsigned seed3)
+{
+  X_seed = seed1;
+  scale_seed = seed2;
+  bias_seed = seed3;
+}
+
+void params::set_seeds()
+{
+  X_seed = std::chrono::system_clock::now().time_since_epoch().count();
+  scale_seed = std::chrono::system_clock::now().time_since_epoch().count();
+  bias_seed = std::chrono::system_clock::now().time_since_epoch().count();
+}
+
+bool params::init_generate(int argc, char** argv)
+{
+  if (argc != 9) {
+    return false;
+  }
+
+  out_dir = argv[1];
+  if ((out_dir.size() > 0u) && (out_dir.back() != '/')) {
+    out_dir += '/';
+  }
+  create_dir(out_dir);
+
+  n_samples = static_cast<unsigned>(std::max(atoi(argv[2]), 0));
+  n_per_file = static_cast<unsigned>(std::max(atoi(argv[3]), 1));
+  n_files = (n_samples + n_per_file - 1) / n_per_file;
+  n_full_files = n_samples / n_per_file;
+  n_remainder = n_samples - n_per_file * n_full_files;
+
+  scale_mean = static_cast<unsigned>(atof(argv[4]));
+  scale_var = static_cast<unsigned>(atof(argv[5]));
+  bias_mean = static_cast<unsigned>(atof(argv[6]));
+  bias_var = static_cast<unsigned>(atof(argv[7]));
+
+  is_binary = static_cast<bool>(atoi(argv[8]));
+
+  X_gen.seed(X_seed);
+  scale_gen.seed(scale_seed);
+  bias_gen.seed(bias_seed);
+
+  X_distribution.param(dist_param_t(0.0, 1.0));
+  X_distribution.reset();
+
+  scale_distribution.param(dist_param_t(scale_mean, scale_var));
+  scale_distribution.reset();
+
+  bias_distribution.param(dist_param_t(bias_mean, bias_var));
+  bias_distribution.reset();
+
+  return true;
+};
+
+
+bool params::init_compare(int argc, char** argv)
+{
+  if (argc != 7) {
+    return false;
+  }
+
+  scale_mean = static_cast<unsigned>(atof(argv[3]));
+  scale_var = static_cast<unsigned>(atof(argv[4]));
+  bias_mean = static_cast<unsigned>(atof(argv[5]));
+  bias_var = static_cast<unsigned>(atof(argv[6]));
+
+  epsilon.first = std::pow(10, 1 - _SSG_TXT_OUTPUT_PRECISION_);
+  epsilon.second = 10 * epsilon.first * (std::abs(scale_mean) + std::abs(bias_mean));
+
+  return true;
+};
+
+
+sample_t params::generate_a_sample()
+{
+  const val_t X     = X_distribution(X_gen);
+  const val_t scale = scale_distribution(scale_gen);
+  const val_t bias  = bias_distribution(bias_gen);
+    
+  const val_t Y = X * scale + bias;
+
+  return sample_t(X, Y);
+}
+
+} // end of namespce synthetic_sample_generator

--- a/src/synthetic_data_generator/params.hpp
+++ b/src/synthetic_data_generator/params.hpp
@@ -1,0 +1,49 @@
+#ifndef __SSG_PARAMS_HPP__
+#define __SSG_PARAMS_HPP__
+#include "sample_t.hpp"
+#include <string>
+#include <random>
+#include <chrono>
+
+namespace synthetic_sample_generator {
+
+struct params
+{
+  void set_seeds(unsigned seed1, unsigned seed2, unsigned seed3);
+  void set_seeds();
+  bool init_generate(int argc, char** argv);
+  bool init_compare(int argc, char** argv);
+  sample_t generate_a_sample();
+
+  unsigned n_samples;
+  unsigned n_per_file;
+  unsigned n_files;
+  unsigned n_full_files;
+  unsigned n_remainder;
+  std::string out_dir;
+
+  val_t scale_mean;
+  val_t scale_var;
+  val_t bias_mean;
+  val_t bias_var;
+  sample_t epsilon;
+
+  bool is_binary;
+
+  unsigned X_seed;
+  unsigned scale_seed;
+  unsigned bias_seed;
+
+  std::default_random_engine X_gen;
+  std::default_random_engine scale_gen;
+  std::default_random_engine bias_gen;
+
+  using dist_param_t = std::normal_distribution<val_t>::param_type;
+
+  std::normal_distribution<val_t> X_distribution;
+  std::normal_distribution<val_t> scale_distribution;
+  std::normal_distribution<val_t> bias_distribution;
+};
+
+} // end of namespce synthetic_sample_generator
+#endif // __SSG_PARAMS_T_HPP__

--- a/src/synthetic_data_generator/sample_file.cpp
+++ b/src/synthetic_data_generator/sample_file.cpp
@@ -1,0 +1,140 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include <cmath>
+#include "sample_t.hpp"
+#include "sample_file.hpp"
+
+namespace synthetic_sample_generator {
+
+bool generate_a_file(const std::string& ofile_name,
+                     const unsigned num_samples,
+                     params& p,
+                     std::vector<sample_t>& samples)
+{
+    samples.clear();
+
+    for (unsigned ns = 0u; ns < num_samples; ++ns) {
+      samples.emplace_back(p.generate_a_sample());
+    }
+
+    std::ios_base::openmode ofile_mode = p.is_binary? (std::ios::out | std::ios::binary) : std::ios::out;
+    std::ofstream ofile{ofile_name, ofile_mode};
+
+    if (p.is_binary) {
+    #if 0
+      std::for_each(samples.cbegin(), samples.cend(),
+                    print_pair<sample_t, true>(ofile));
+    #else
+      ofile.write(reinterpret_cast<const char*>(samples.data()), samples.size()*sizeof(sample_t));
+    #endif
+    } else {
+      std::for_each(samples.cbegin(), samples.cend(),
+                    print_pair<sample_t, false>(ofile));
+    }
+
+    ofile.close();
+
+  #if defined(__SSG_DEBUG__)
+    for (const auto& sample: samples) {
+      std::cout << sample.first << "\t" << sample.second << std::endl;
+    }
+  #endif
+
+    return true;
+}
+
+
+bool load_a_file(const std::string& ifile_name,
+                 std::vector<sample_t>& samples)
+{
+  samples.clear();
+
+  const std::size_t found = ifile_name.find_last_of(".");
+  const std::string file_ext = ifile_name.substr(found+1);
+
+  const bool is_binary = (file_ext != "txt");
+
+  std::ios_base::openmode ifile_mode = is_binary? (std::ios::in | std::ios::binary) : std::ios::in;
+  std::ifstream ifile{ifile_name, ifile_mode};
+
+  if (!ifile.is_open()) {
+    std::cerr << "Unable to open file: " << ifile_name << std::endl;
+    return false;
+  }
+
+  if (is_binary) {
+    ifile.seekg(0,  std::ios::end);
+    const std::streampos fsize = ifile.tellg();
+    const unsigned num_samples = fsize / sizeof(sample_t);
+    if (static_cast<std::streampos>(num_samples * sizeof(sample_t)) != fsize) {
+      std::cerr << "Corrupted file? " << num_samples << " * " << sizeof(sample_t) << " != " << fsize << std::endl;
+      ifile.close();
+      return false;
+    }
+    ifile.seekg(0, std::ios::beg);
+    samples.resize(num_samples);
+    ifile.read(reinterpret_cast<char*>(samples.data()), num_samples*sizeof(sample_t));
+  } else {
+    std::string sample;
+    while ( getline (ifile, sample) )
+    {
+      const std::size_t found = sample.find_first_of(",");
+      if (found == std::string::npos) {
+        std::cerr << "Invalid format: missing comma in \"" << sample << '"' << std::endl;
+        ifile.close();
+        return false;
+      }
+      const std::string X_string = sample.substr(0, found);
+      const std::string Y_string = sample.substr(found+1);
+      std::istringstream X_sstr(X_string);
+      std::istringstream Y_sstr(Y_string);
+      val_t X, Y;
+      X_sstr >> X;
+      Y_sstr >> Y;
+      samples.emplace_back(std::make_pair(X,Y));
+    }
+  }
+
+  ifile.close();
+
+#if defined(__SSG_DEBUG__)
+  for (const auto& sample: samples) {
+    std::cout << sample.first << "\t" << sample.second << std::endl;
+  }
+#endif
+  return true;
+}
+
+bool compare(const std::string& file1, const std::string& file2, const params& p)
+{
+  bool ok = true;
+
+  std::vector<sample_t> samples1;
+  std::vector<sample_t> samples2;
+
+  ok = ok && load_a_file(file1, samples1);
+  ok = ok && load_a_file(file2, samples2);
+  ok = ok && (samples1.size() == samples2.size());
+
+  for(size_t i = 0u; i < samples1.size(); ++i) {
+    if ((std::abs(samples1[i].first - samples2[i].first) > p.epsilon.first) || (std::abs(samples1[i].second - samples2[i].second) > p.epsilon.second)) {
+      ok = false;
+
+      std::cerr << "At line " << i << std::setprecision(_SSG_TXT_OUTPUT_PRECISION_) << " (" << samples1[i].first << ' ' << samples1[i].second << ") != (" << samples2[i].first << ' ' << samples2[i].second << ')' << std::endl;
+      if (std::abs(samples1[i].first - samples2[i].first) > p.epsilon.first) {
+        std::cerr << std::abs(samples1[i].first - samples2[i].first) << " > " << p.epsilon.first << std::endl;
+      } else {
+        std::cerr << std::abs(samples1[i].second - samples2[i].second) << " > " << p.epsilon.second << std::endl;
+      }
+      break;
+    }
+  }
+
+  return ok;
+}
+
+} // end of namespce synthetic_sample_generator
+

--- a/src/synthetic_data_generator/sample_file.hpp
+++ b/src/synthetic_data_generator/sample_file.hpp
@@ -1,0 +1,20 @@
+#ifndef __SSG_SAMPLE_FILE_HPP__
+#define __SSG_SAMPLE_FILE_HPP__
+#include <string>
+#include <vector>
+#include "sample_t.hpp"
+#include "params.hpp"
+
+namespace synthetic_sample_generator {
+
+bool generate_a_file(const std::string& ofile_name, const unsigned num_samples,
+                     params& p, std::vector<sample_t>& samples);
+
+
+bool load_a_file(const std::string& ifile_name, std::vector<sample_t>& samples);
+
+bool compare(const std::string& file1, const std::string& file2, const params& p);
+
+} // end of namespce synthetic_sample_generator
+#endif // __SSG_SAMPLE_FILE_HPP__
+

--- a/src/synthetic_data_generator/sample_t.hpp
+++ b/src/synthetic_data_generator/sample_t.hpp
@@ -1,0 +1,42 @@
+#ifndef __SSG_SAMPLE_T_HPP__
+#define __SSG_SAMPLE_T_HPP__
+#include <iostream>
+#include <iomanip>
+
+#define _SSG_TXT_OUTPUT_PRECISION_ 9
+
+namespace synthetic_sample_generator {
+
+using val_t = double;
+using sample_t = std::pair<val_t, val_t>;
+
+
+template <class T, bool>
+struct print_pair : public std::unary_function<T, void> {};
+
+template <class T>
+struct print_pair<T, false>
+{
+  std::ostream& os;
+  print_pair(std::ostream& strm) : os(strm) {}
+
+  void operator()(const T& elem) const
+  {
+    os << std::setprecision(_SSG_TXT_OUTPUT_PRECISION_) << elem.first << ", " << elem.second << std::endl;
+  }
+};
+
+template <class T>
+struct print_pair<T, true>
+{
+  std::ostream& os;
+  print_pair(std::ostream& strm) : os(strm) {}
+
+  void operator()(const T& elem) const
+  {
+    os.write(&elem, sizeof(sample_t));
+  }
+};
+
+} // end of namespce synthetic_sample_generator
+#endif // __SSG_SAMPLE_T_HPP__


### PR DESCRIPTION
This PR adds a simple synthetic data generator for testing.
This produces file that contains two columns filled with randomly generated numbers.
This relies on ostream write() call to generate text/binary files. 